### PR TITLE
gitignore: Ignore .gz, .csv files but whitelist test- prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 # Ignore any target directories
 target/
+
+# Ignore all un-test-related .csv files and .gz files
+*.gz
+*.csv
+!test-*


### PR DESCRIPTION
This is done to allow for storing dump files in the same directory as this project, but also to allow for storing example data in this repository for testing purposes.